### PR TITLE
Changed font from Montserrat to Roboto Condensed

### DIFF
--- a/assets/sass/_main.scss
+++ b/assets/sass/_main.scss
@@ -41,8 +41,8 @@ h6 { font-size: .875rem; margin-top: 1rem;}
 
 
 .sidefnt {
-  font-family: 'Montserrat', sans-serif;
-  font-weight: 200;
+  font-family: 'Roboto Condensed', sans-serif;
+  font-weight: 300;
   font-size: 1rem;
 }
 

--- a/layouts/partials/site-styles.html
+++ b/layouts/partials/site-styles.html
@@ -1,5 +1,5 @@
 
-<link href="https://fonts.googleapis.com/css?family=Montserrat:200,400&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Josefin+Slab:400,600&display=swap" rel="stylesheet">
 


### PR DESCRIPTION
The sidebars start overflowing with a wide font such as Montserrant, hence shifted over to a condensed sans-serif.