### PR TITLE
Added support for specifying column width with columns

### DIFF
--- a/assets/sass/_shortcodes.scss
+++ b/assets/sass/_shortcodes.scss
@@ -10,7 +10,18 @@
 }
 
 .flex-1 {
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+.flex-bauto {
+  flex-basis: auto;
+}
+$i: 0;
+@for $i from 0 through 20 {
+  $j: $i * 5;
+  .flex-b#{$j} {
+    flex-basis: $j * 1%;
+  }
 }
 
 .katex {
@@ -118,3 +129,10 @@
   }
 }
 
+.book-columns figure { /* Remove margins for figures inside columns */
+    display: block;
+    margin-block-start: 0; /* default for figure is 1em */
+    margin-block-end: 0; /* default for figure is 1em */
+    margin-inline-start: 0; /* default for figure is 40px */
+    margin-inline-end: 0; /* default for figure is 40px */
+}

--- a/layouts/shortcodes/columns.html
+++ b/layouts/shortcodes/columns.html
@@ -1,7 +1,21 @@
 <div class="book-columns flex justify-between">
-  {{ range split .Inner "<--->" }}
-  <div class="flex-1">
-    {{ . | markdownify }}
+  {{ $column_contents := split .Inner "<--->" }}
+
+  {{ $x := slice }}
+  {{ $param := .Get 0 }}
+  {{ range $i, $v := (seq (len $column_contents)) }}
+    {{ if $param }}
+      {{ $widths := split $param "," }}
+      {{ $x = $x | append (index $widths $i) }}
+    {{ else }}
+      {{ $x = $x | append 0 }}
+    {{ end }}
+  {{ end }}
+
+  {{ range $index, $element := $column_contents }}
+  <div class="flex-1 flex-b{{ index $x $index }} ">
+    {{ $element | markdownify }}
   </div>
   {{ end }}
 </div>
+


### PR DESCRIPTION
Using the flex-basis % css. Expects comma-separated value of column-widths adding up to 100, like "20,60,20". If not specificed, defaults to equal widths for all columns.